### PR TITLE
Ignore Dependabot PRs in Playwright workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-white-cliff-0499a1310.yml
+++ b/.github/workflows/azure-static-web-apps-white-cliff-0499a1310.yml
@@ -16,6 +16,8 @@ on:
             - "docs/**"
             - "src/**"
             - "./index.js"
+        branches-ignore:
+            - "dependabot/**"
 
 jobs:
     build_and_deploy_job:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,11 @@
 name: Playwright Tests
 on:
     push:
-        branches: [main, master]
+        branches: main
     pull_request:
-        branches: [main, master]
+        branches: main
+        branches-ignore:
+            - "dependabot/**"
 jobs:
     test:
         timeout-minutes: 60


### PR DESCRIPTION
Update the Playwright workflow to restrict branch triggers and ignore Dependabot pull requests.