### PR TITLE
Improve resize and drag state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Fixed visual issue where resizing elements caused the text inside of the element to be selected.
+- Fixed issue where dragging elements did not disable the content editing mode.
+- Fixed issue where elements with `box-sizing: content-box` and padding were not resized correctly.
 - Added status badges to the README.md file.
 - Added a contributor section to the README.md file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a console warning when users try to resize a rotated element: "Remarklet does not yet support resizing rotated elements."
+- Added status badges to the README.md file.
+- Added a contributor section to the README.md file.
+
 ### Changed
 
 - Fixed visual issue where resizing elements caused the text inside of the element to be selected.
 - Fixed issue where dragging elements did not disable the content editing mode.
 - Fixed issue where elements with `box-sizing: content-box` and padding were not resized correctly.
-- Added status badges to the README.md file.
-- Added a contributor section to the README.md file.
+
+### Removed
+
+- Removed incomplete solution for resizing rotated elements.
 
 ## [1.0.3] - 2025-03-18
 

--- a/src/drag.js
+++ b/src/drag.js
@@ -3,6 +3,7 @@ import store from "./store.js";
 
 let interactable = null;
 let inlineTarget = null;
+let warnedOfRotation = false;
 
 export function main() {
     store.subscribe("target", (target) => {
@@ -122,7 +123,8 @@ const resizableOptions = {
         },
         move(event) {
             const target = event.target;
-            if (hasRotation(target)) {
+            if (hasRotation(target) && !warnedOfRotation) {
+                warnedOfRotation = true;
                 console.warn(
                     "Resizing rotated elements is not yet supported.",
                 );

--- a/src/drag.js
+++ b/src/drag.js
@@ -126,7 +126,7 @@ const resizableOptions = {
             if (hasRotation(target) && !warnedOfRotation) {
                 warnedOfRotation = true;
                 console.warn(
-                    "Resizing rotated elements is not yet supported.",
+                    "Remarklet does not yet support resizing rotated elements.",
                 );
             }
             target.style.width = resolveWidth(target, event.rect.width);

--- a/src/drag.js
+++ b/src/drag.js
@@ -125,9 +125,7 @@ const resizableOptions = {
             const target = event.target;
             if (hasRotation(target) && !warnedOfRotation) {
                 warnedOfRotation = true;
-                console.warn(
-                    "Remarklet does not yet support resizing rotated elements.",
-                );
+                console.warn("Remarklet does not yet support resizing rotated elements.");
             }
             target.style.width = resolveWidth(target, event.rect.width);
             target.style.height = resolveHeight(target, event.rect.height);

--- a/src/drag.js
+++ b/src/drag.js
@@ -122,26 +122,28 @@ const resizableOptions = {
         },
         move(event) {
             const target = event.target;
+            target.style.width = resolveWidth(target, event.rect.width);
+            target.style.height = resolveHeight(target, event.rect.height);
             // Resolve whether to change the width or the height.
-            const rect = target.getBoundingClientRect();
-            if (event.rect.height === rect.height) {
-                // Element is not rotated.
-                target.style.width = event.rect.width + "px";
-                target.style.height = event.rect.height + "px";
-            } else {
-                // Element is rotated.
-                target.style.width = event.rect.height + "px";
-                target.style.height = event.rect.width + "px";
-            }
-            const x =
-                (parseFloat(target.getAttribute("data-remarklet-x")) || 0) + event.deltaRect.left;
-            const y =
-                (parseFloat(target.getAttribute("data-remarklet-y")) || 0) + event.deltaRect.top;
-            const originalTransform = target.getAttribute("data-remarklet-original-transform");
-            const resolved = resolveTransform(target, x, y, originalTransform);
-            target.style.transform = resolved.style;
-            target.setAttribute("data-remarklet-x", resolved.x);
-            target.setAttribute("data-remarklet-y", resolved.y);
+            // const rect = target.getBoundingClientRect();
+            // if (event.rect.height === rect.height) {
+            //     // Element is not rotated.
+            //     target.style.width = event.rect.width + "px";
+            //     target.style.height = event.rect.height + "px";
+            // } else {
+            //     // Element is rotated.
+            //     target.style.width = event.rect.height + "px";
+            //     target.style.height = event.rect.width + "px";
+            // }
+            // const x =
+            //     (parseFloat(target.getAttribute("data-remarklet-x")) || 0) + event.deltaRect.left;
+            // const y =
+            //     (parseFloat(target.getAttribute("data-remarklet-y")) || 0) + event.deltaRect.top;
+            // const originalTransform = target.getAttribute("data-remarklet-original-transform");
+            // const resolved = resolveTransform(target, x, y, originalTransform);
+            // target.style.transform = resolved.style;
+            // target.setAttribute("data-remarklet-x", resolved.x);
+            // target.setAttribute("data-remarklet-y", resolved.y);
         },
         end(event) {
             store.set("mode", "edit");
@@ -149,6 +151,38 @@ const resizableOptions = {
         },
     },
 };
+
+/**
+ * The totalWidth does not consider the CSS box-sizing property.
+ * @param {HTMLElement} target The target element
+ * @param {number} totalWidth The total width of the element
+ * @returns {string} The resolved width in px
+ */
+function resolveWidth(target, totalWidth) {
+    const computedStyle = window.getComputedStyle(target);
+    if (computedStyle.boxSizing === "border-box") {
+        return `${totalWidth}px`;
+    }
+    const paddingLeft = parseFloat(computedStyle.paddingLeft);
+    const paddingRight = parseFloat(computedStyle.paddingRight);
+    return `${totalWidth - paddingLeft - paddingRight}px`;
+}
+
+/**
+ * The totalHeight does not consider the CSS box-sizing property.
+ * @param {HTMLElement} target The target element
+ * @param {number} totalWidth The total height of the element
+ * @returns {string} The resolved height in px
+ */
+function resolveHeight(target, totalHeight) {
+    const computedStyle = window.getComputedStyle(target);
+    if (computedStyle.boxSizing === "border-box") {
+        return `${totalHeight}px`;
+    }
+    const paddingTop = parseFloat(computedStyle.paddingTop);
+    const paddingBottom = parseFloat(computedStyle.paddingBottom);
+    return `${totalHeight - paddingTop - paddingBottom}px`;
+}
 
 function resolveTransform(target, x, y, originalTransform) {
     let style = "";

--- a/src/drag.js
+++ b/src/drag.js
@@ -53,10 +53,11 @@ const draggableOptions = {
                 }
                 if (parent) {
                     store.set("target", parent);
+                    parent.setAttribute("data-remarklet-dragging", "true");
                     inlineTarget = event.target;
                 }
             } else {
-                store.set("target", event.target);
+                event.target.setAttribute("data-remarklet-dragging", "true");
             }
         },
         /**
@@ -92,16 +93,12 @@ const draggableOptions = {
             if (!target) {
                 return;
             }
+            target.removeAttribute("data-remarklet-dragging");
             if (event.target === inlineTarget) {
                 store.set("target", inlineTarget);
                 inlineTarget = null;
-                store.set("mode", "idle");
-                return;
             }
-            if (event.target !== target) {
-                return;
-            }
-            store.set("mode", "idle");
+            store.set("mode", "edit");
         },
     },
 };
@@ -110,8 +107,12 @@ const resizableOptions = {
     edges: { left: true, right: true, bottom: true, top: false },
     listeners: {
         start(event) {
+            if (store.get("modifying")) {
+                return;
+            }
             // An inline element cannot be resized. I can't decide the least surprising behavior here.
             store.set("mode", "resizing");
+            event.target.setAttribute("data-remarklet-resizing", "true");
             if (event.target.getAttribute("data-remarklet-original-transform") === null) {
                 event.target.setAttribute(
                     "data-remarklet-original-transform",
@@ -143,7 +144,8 @@ const resizableOptions = {
             target.setAttribute("data-remarklet-y", resolved.y);
         },
         end(event) {
-            store.set("mode", "idle");
+            store.set("mode", "edit");
+            event.target.removeAttribute("data-remarklet-resizing");
         },
     },
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
 const state = {
-    mode: "idle",
+    mode: "edit",
     dragging: false,
     resizing: false,
     target: null,
@@ -50,6 +50,19 @@ export function get(key) {
     return state[key];
 }
 
+/**
+ * @typedef {function} SubscriberCallback
+ * @callback SubscriberCallback
+ * @param {any} value - The new value of the state.
+ * @param {any} oldValue - The old value of the state.
+ * @returns {void}
+ */
+/**
+ * Subscribe function
+ * @param {string} key - The key to subscribe to.
+ * @param {SubscriberCallback} callback - The callback function to call when the state changes.
+ * @returns {void}
+ */
 export function subscribe(key, callback) {
     subscribers[key].push(callback);
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -4,8 +4,13 @@
  */
 export default function main() {
     const styles = `
-.remarklet-highlight {
+[data-remarklet-highlight] {
     outline: 2px solid #00b3dd;
+}
+[data-remarklet-dragging],
+[data-remarklet-resizing] {
+    user-select: none !important;
+    -webkit-user-select: none !important;
 }
 `;
     const styleSheet = document.createElement("style");

--- a/src/target.js
+++ b/src/target.js
@@ -4,8 +4,6 @@
  */
 import store from "./store.js";
 
-export const highlightClass = "remarklet-highlight";
-
 const mouseEnterStack = [];
 
 /**
@@ -24,15 +22,15 @@ export default function main() {
     store.subscribe("target", (target, oldTarget) => {
         if (!store.get("active")) {
             if (target) {
-                target.classList.remove(highlightClass);
+                target.removeAttribute("data-remarklet-highlight");
             }
             if (oldTarget) {
-                oldTarget.classList.remove(highlightClass);
+                oldTarget.removeAttribute("data-remarklet-highlight");
             }
             return;
         }
-        target?.classList.add(highlightClass);
-        oldTarget?.classList.remove(highlightClass);
+        target?.setAttribute("data-remarklet-highlight", "true");
+        oldTarget?.removeAttribute("data-remarklet-highlight");
     });
 }
 
@@ -43,8 +41,8 @@ export default function main() {
 function handleMouseEnter(event) {
     event.stopPropagation();
     if (event.target.classList && !store.get("modifying")) {
-        mouseEnterStack.push(event.target);
         store.set("target", event.target);
+        mouseEnterStack.push(event.target);
     }
 }
 

--- a/src/textedit.js
+++ b/src/textedit.js
@@ -1,23 +1,25 @@
 import store from "./store.js";
 
-let contentTarget = null;
-
 export default function main() {
-    store.subscribe("target", (target) => {
+    store.subscribe("target", (target, oldTarget) => {
+        if (oldTarget) {
+            oldTarget.removeAttribute("contenteditable");
+        }
         if (!store.get("active")) {
-            if (contentTarget) {
-                contentTarget.removeAttribute("contenteditable");
-                contentTarget = null;
-            }
             return;
         }
-        if (contentTarget) {
-            contentTarget.removeAttribute("contenteditable");
-            contentTarget = null;
-        }
-        if (target) {
-            contentTarget = target;
+        if (target && "edit" === store.get("mode")) {
             target.setAttribute("contenteditable", "true");
+        }
+    });
+    store.subscribe("mode", (mode) => {
+        if (mode === "edit") {
+            store.get("target")?.setAttribute("contenteditable", "true");
+        } else {
+            const target = store.get("target");
+            if (target && target.hasAttribute("contenteditable")) {
+                target.removeAttribute("contenteditable");
+            }
         }
     });
 }


### PR DESCRIPTION
### Added

- Added a console warning when users try to resize a rotated element: "Remarklet does not yet support resizing rotated elements."

### Changed

- Fixed visual issue where resizing elements caused the text inside of the element to be selected.
- Fixed issue where dragging elements did not disable the content editing mode.
- Fixed issue where elements with `box-sizing: content-box` and padding were not resized correctly.

### Removed

- Removed incomplete solution for resizing rotated elements.
