### PR TITLE
Improve resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Resizing will now only set the width or height of the element during the action, not both at the same time.
 - Fixed visual issue where resizing elements caused the text inside of the element to be selected.
 - Fixed issue where dragging elements did not disable the content editing mode.
 - Fixed issue where elements with `box-sizing: content-box` and padding were not resized correctly.

--- a/src/drag.js
+++ b/src/drag.js
@@ -127,8 +127,11 @@ const resizableOptions = {
                 warnedOfRotation = true;
                 console.warn("Remarklet does not yet support resizing rotated elements.");
             }
-            target.style.width = resolveWidth(target, event.rect.width);
-            target.style.height = resolveHeight(target, event.rect.height);
+            if (event.edges.left || event.edges.right) {
+                target.style.width = resolveWidth(target, event.rect.width);
+            } else if (event.edges.top || event.edges.bottom) {
+                target.style.height = resolveHeight(target, event.rect.height);
+            }
 
             // const rect = target.getBoundingClientRect();
             // if (event.rect.height === rect.height) {


### PR DESCRIPTION
### What's being changed

Resizing will now only set the width or height of the element during the action, not both at the same time.
