### PR TITLE
Reduce build size by optimizing InteractJS imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Improved touch support for dragging and resizing elements.
 - Renamed `demo/cdn.html` to `demo/dev.html` to clarify the purpose of the file is to experiment with features during development.
+- Split dependencies to reduce uncompressed package size by more than 25kb.
 
 ## [1.0.4] - 2025-03-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
             "version": "1.0.4",
             "license": "MIT",
             "dependencies": {
-                "interactjs": "^1.10.27"
+                "@interactjs/actions": "^1.10.27",
+                "@interactjs/auto-start": "^1.10.27",
+                "@interactjs/dev-tools": "^1.10.27",
+                "@interactjs/interact": "^1.10.27",
+                "@interactjs/modifiers": "^1.10.27"
             },
             "devDependencies": {
                 "@playwright/test": "^1.51.0",
@@ -24,10 +28,147 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@interactjs/types": {
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+            "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/types": "^7.26.10"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+            "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.25.9"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@interactjs/actions": {
             "version": "1.10.27",
-            "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
-            "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
+            "resolved": "https://registry.npmjs.org/@interactjs/actions/-/actions-1.10.27.tgz",
+            "integrity": "sha512-FCRg5KwB+stkPcAMx/Cn0fgGP6p4LyMX9S/Upcn/W+hpYme31bPi54PCqmOebzz6myTthN6zFf9jMyLOqtI/gg==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@interactjs/interact": "1.10.27"
+            },
+            "peerDependencies": {
+                "@interactjs/core": "1.10.27",
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/auto-start": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/auto-start/-/auto-start-1.10.27.tgz",
+            "integrity": "sha512-ECLBO/nxmaF1knncJKIE5F7la3KKRgEkn0Cu2JTPOYj9xy/LpfYElo3wkRHsodgOqF651nR70GK2/IzPR2lO9A==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@interactjs/interact": "1.10.27"
+            },
+            "peerDependencies": {
+                "@interactjs/core": "1.10.27",
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/core": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/core/-/core-1.10.27.tgz",
+            "integrity": "sha512-SliUr/3ZbLAdED8LokzYzWHWMdCB5Cq+UnpXuRy+BIod1j97m4IUFf/D1iIKUBBjBcucgXbz28z96WnenVCB7Q==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/dev-tools": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/dev-tools/-/dev-tools-1.10.27.tgz",
+            "integrity": "sha512-YolmBwRaKH1gWbvyLeV3m5QSwtD38lOZnCBA87PCAlcd9PQAC2gb03fEPeEyD336bE20oLB8f0WZt4Wre+afiw==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@interactjs/interact": "1.10.27",
+                "vue": "3"
+            },
+            "peerDependencies": {
+                "@interactjs/modifiers": "1.10.27",
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/interact": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/interact/-/interact-1.10.27.tgz",
+            "integrity": "sha512-XdH3A2UUzjEFGGJgFuJlhiz99tE8jB8xNh/DmnoMuL6uOQPxNA+sWRnzEVjG0+zY2P3/dbhEpi4Cn3FLPzydwA==",
+            "license": "MIT",
+            "dependencies": {
+                "@interactjs/core": "1.10.27",
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/modifiers": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/modifiers/-/modifiers-1.10.27.tgz",
+            "integrity": "sha512-ei/qfoQ+9/8k6WzNzdNqHI6cWkIV576N4Ap16r5CoqOWwhA6Xzj3OMHf1g0t1O4eSq2HdJsVJn3eLNfw9HsbeQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@interactjs/snappers": "1.10.27"
+            },
+            "optionalDependencies": {
+                "@interactjs/interact": "1.10.27"
+            },
+            "peerDependencies": {
+                "@interactjs/core": "1.10.27",
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/snappers": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/snappers/-/snappers-1.10.27.tgz",
+            "integrity": "sha512-HZLZ0XSi6HI08OmTv/HKG6AltQoaKAALLQ+KDW92utj3XSgw7oren0KsWUKPhaPg3Av7R1jFQd08s+uafqIlLw==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "@interactjs/interact": "1.10.27"
+            },
+            "peerDependencies": {
+                "@interactjs/utils": "1.10.27"
+            }
+        },
+        "node_modules/@interactjs/utils": {
+            "version": "1.10.27",
+            "resolved": "https://registry.npmjs.org/@interactjs/utils/-/utils-1.10.27.tgz",
+            "integrity": "sha512-+qfLOio2OxQqg1cXSnRaCl+N8MQDQLDS9w+aOGxH8YLAhIMyt7Asxx/46//sT8orgsi16pmlBPtngPHT9s8zKw==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -80,7 +221,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -509,6 +650,115 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+            "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/shared": "3.5.13",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+            "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+            "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/compiler-core": "3.5.13",
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.11",
+                "postcss": "^8.4.48",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+            "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+            "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+            "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.13",
+                "@vue/shared": "3.5.13"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+            "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.13",
+                "@vue/runtime-core": "3.5.13",
+                "@vue/shared": "3.5.13",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+            "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.13",
+                "@vue/shared": "3.5.13"
+            },
+            "peerDependencies": {
+                "vue": "3.5.13"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+            "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/acorn": {
             "version": "8.14.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -543,6 +793,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/csstype": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -553,11 +810,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fdir": {
@@ -613,15 +883,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/interactjs": {
-            "version": "1.10.27",
-            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
-            "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
-            "license": "MIT",
-            "dependencies": {
-                "@interactjs/types": "1.10.27"
-            }
-        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -659,10 +920,29 @@
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
         "node_modules/path-parse": {
@@ -671,6 +951,13 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC",
+            "optional": true
         },
         "node_modules/picomatch": {
             "version": "4.0.2",
@@ -715,6 +1002,35 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/prettier": {
@@ -851,6 +1167,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -892,6 +1218,28 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/vue": {
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+            "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.13",
+                "@vue/compiler-sfc": "3.5.13",
+                "@vue/runtime-dom": "3.5.13",
+                "@vue/server-renderer": "3.5.13",
+                "@vue/shared": "3.5.13"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "interactjs": "^1.10.27"
+        "@interactjs/actions": "^1.10.27",
+        "@interactjs/auto-start": "^1.10.27",
+        "@interactjs/dev-tools": "^1.10.27",
+        "@interactjs/interact": "^1.10.27",
+        "@interactjs/modifiers": "^1.10.27"
     },
     "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/src/drag.js
+++ b/src/drag.js
@@ -1,9 +1,9 @@
-import '@interactjs/auto-start/index.prod'
-import '@interactjs/actions/drag/index.prod'
-import '@interactjs/actions/resize/index.prod'
-import '@interactjs/modifiers/index.prod'
+import "@interactjs/auto-start/index.prod";
+import "@interactjs/actions/drag/index.prod";
+import "@interactjs/actions/resize/index.prod";
+import "@interactjs/modifiers/index.prod";
 // import '@interactjs/dev-tools'
-import interact from '@interactjs/interact/index.prod'
+import interact from "@interactjs/interact/index.prod";
 import store from "./store.js";
 
 let interactable = null;

--- a/src/drag.js
+++ b/src/drag.js
@@ -1,4 +1,9 @@
-import interact from "interactjs";
+import '@interactjs/auto-start/index.prod'
+import '@interactjs/actions/drag/index.prod'
+import '@interactjs/actions/resize/index.prod'
+import '@interactjs/modifiers/index.prod'
+// import '@interactjs/dev-tools'
+import interact from '@interactjs/interact/index.prod'
 import store from "./store.js";
 
 let interactable = null;


### PR DESCRIPTION
Optimize the imports from InteractJS to reduce the overall build size, following the recommendations in the documentation.