### PR TITLE
Remove unused modifiers package and update size savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Improved touch support for dragging and resizing elements.
 - Renamed `demo/cdn.html` to `demo/dev.html` to clarify the purpose of the file is to experiment with features during development.
-- Split dependencies to reduce uncompressed package size by more than 25kb.
+- Split dependencies to reduce uncompressed package size by more than 45kb.
 
 ## [1.0.4] - 2025-03-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
                 "@interactjs/actions": "^1.10.27",
                 "@interactjs/auto-start": "^1.10.27",
                 "@interactjs/dev-tools": "^1.10.27",
-                "@interactjs/interact": "^1.10.27",
-                "@interactjs/modifiers": "^1.10.27"
+                "@interactjs/interact": "^1.10.27"
             },
             "devDependencies": {
                 "@playwright/test": "^1.51.0",
@@ -142,6 +141,7 @@
             "resolved": "https://registry.npmjs.org/@interactjs/modifiers/-/modifiers-1.10.27.tgz",
             "integrity": "sha512-ei/qfoQ+9/8k6WzNzdNqHI6cWkIV576N4Ap16r5CoqOWwhA6Xzj3OMHf1g0t1O4eSq2HdJsVJn3eLNfw9HsbeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@interactjs/snappers": "1.10.27"
             },
@@ -158,6 +158,7 @@
             "resolved": "https://registry.npmjs.org/@interactjs/snappers/-/snappers-1.10.27.tgz",
             "integrity": "sha512-HZLZ0XSi6HI08OmTv/HKG6AltQoaKAALLQ+KDW92utj3XSgw7oren0KsWUKPhaPg3Av7R1jFQd08s+uafqIlLw==",
             "license": "MIT",
+            "peer": true,
             "optionalDependencies": {
                 "@interactjs/interact": "1.10.27"
             },

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
         "@interactjs/actions": "^1.10.27",
         "@interactjs/auto-start": "^1.10.27",
         "@interactjs/dev-tools": "^1.10.27",
-        "@interactjs/interact": "^1.10.27",
-        "@interactjs/modifiers": "^1.10.27"
+        "@interactjs/interact": "^1.10.27"
     },
     "devDependencies": {
         "@playwright/test": "^1.51.0",

--- a/src/drag.js
+++ b/src/drag.js
@@ -1,7 +1,6 @@
 import "@interactjs/auto-start/index.prod";
 import "@interactjs/actions/drag/index.prod";
 import "@interactjs/actions/resize/index.prod";
-import "@interactjs/modifiers/index.prod";
 // import '@interactjs/dev-tools'
 import interact from "@interactjs/interact/index.prod";
 import store from "./store.js";


### PR DESCRIPTION
Eliminate the unused @interactjs/modifiers package and improve the overall package size savings from over 25kb to more than 45kb.