### PR TITLE
Disable transitions and indicate mode with data attribute

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -20,18 +20,7 @@ export default function main() {
 `);
     document.head.appendChild(stylesheet.element);
 
-    store.subscribe("mode", (mode, lastMode) => {
-        // When the mode is resizing or dragging, add a style to the body using the stylesheet that gives it "user-select: none".
-        if ("dragging" === mode) {
-            document.body.setAttribute("data-remarklet-dragging", "true");
-            if ("resizing" === lastMode) {
-                document.body.removeAttribute("data-remarklet-resizing");
-            }
-        } else if ("resizing" === mode) {
-            document.body.setAttribute("data-remarklet-resizing", "true");
-            if ("dragging" === lastMode) {
-                document.body.removeAttribute("data-remarklet-dragging");
-            }
-        }
+    store.subscribe("mode", (mode) => {
+        document.body.setAttribute("data-remarklet-mode", mode);
     });
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -10,10 +10,12 @@ export default function main() {
 [data-remarklet-highlight] {
     outline: 2px solid #00b3dd;
 }
-body[data-remarklet-dragging],
-body[data-remarklet-resizing] {
-    touch-action: none;
-    user-select: none;
+[data-remarklet-dragging],
+[data-remarklet-resizing] {
+    touch-action: none !important;
+    user-select: none !important;
+    transition: none !important;
+    animation: none !important;
 }
 `);
     document.head.appendChild(stylesheet.element);


### PR DESCRIPTION
Disable transitions and animations for better performance during dragging and resizing. Indicate the current mode using a data attribute on the body element for improved state management.