### PR TITLE
Update version to 1.2.5 and fix outline style issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     pull_request:
         branches:
             - main
+            - "v*"
 
 permissions:
     contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 No unreleased changes.
 
+## [1.2.5] - 2025-05-08
+
+### Fixed
+
+- Fixed an issue where some websites would not show the outline style for the target element.
+
 ## [1.2.4] - 2025-05-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zw/remarklet",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "Remarklet adds visual editing capabilities to any web page.",
     "main": "index.js",
     "type": "module",

--- a/src/styles.js
+++ b/src/styles.js
@@ -15,7 +15,7 @@ export default function main() {
     if (sheet) {
         return sheet;
     }
-    sheet = new Stylesheet();                                  
+    sheet = new Stylesheet();
     sheet.setRule(
         "[data-remarklet-highlight]",
         "outline: 2px solid #00b3dd !important; touch-action: none !important; user-select: none !important;",

--- a/src/styles.js
+++ b/src/styles.js
@@ -15,10 +15,10 @@ export default function main() {
     if (sheet) {
         return sheet;
     }
-    sheet = new Stylesheet();
+    sheet = new Stylesheet();                                  
     sheet.setRule(
         "[data-remarklet-highlight]",
-        "outline: 2px solid #00b3dd; touch-action: none !important; user-select: none !important;",
+        "outline: 2px solid #00b3dd !important; touch-action: none !important; user-select: none !important;",
     );
     sheet.setRule(
         "[data-remarklet-dragging], [data-remarklet-resizing]",


### PR DESCRIPTION
Bump the version to 1.2.5 and document a fix for the outline style not displaying on certain websites in the changelog.